### PR TITLE
feat: Add `bera-geth` to hive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ workspace
 simulators/**/target
 hivesim-rs/Cargo.lock
 hivesim-rs/target
+
+# workspace logs
+hiveview

--- a/clients/bera-geth/.gitignore
+++ b/clients/bera-geth/.gitignore
@@ -1,0 +1,1 @@
+go-ethereum

--- a/clients/bera-geth/Dockerfile
+++ b/clients/bera-geth/Dockerfile
@@ -1,0 +1,32 @@
+# Pull bera-geth image
+ARG baseimage=ghcr.io/berachain/bera-geth
+ARG tag=v1.011602.1
+
+FROM $baseimage:$tag as builder
+
+FROM alpine:latest
+RUN apk add --update bash curl jq
+
+# Use bera-geth instead of geth
+COPY --from=builder /usr/local/bin/bera-geth /usr/local/bin/geth
+
+# Generate the version.txt file.
+RUN /usr/local/bin/geth console --exec 'console.log(admin.nodeInfo.name)' --maxpeers=0 --nodiscover --dev 2>/dev/null | head -1 > /version.txt
+
+# Inject the startup script.
+ADD geth.sh /geth.sh
+ADD mapper.jq /mapper.jq
+RUN chmod +x /geth.sh
+
+# Inject the enode id retriever script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Add a default genesis file.
+ADD genesis.json /genesis.json
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8547 8551 30303 30303/udp
+
+ENTRYPOINT ["/geth.sh"]

--- a/clients/bera-geth/Dockerfile.git
+++ b/clients/bera-geth/Dockerfile.git
@@ -1,0 +1,44 @@
+## Pulls geth from a git repository and builds it from source.
+
+FROM golang:1.23-alpine as builder
+ARG github=ethereum/go-ethereum
+ARG tag=master
+ARG GOPROXY
+
+ENV GOPROXY=${GOPROXY}
+
+RUN \
+  apk add --update bash curl jq git make gcc musl-dev                 \
+  ca-certificates linux-headers                                    && \
+  echo "Cloning: $github - $tag"                                   && \
+  git clone --depth 1 --branch $tag https://github.com/$github     && \
+  cd go-ethereum                                                   && \
+  make geth                                                        && \
+  cp build/bin/geth /usr/local/bin/geth                            && \
+  apk del go git make gcc musl-dev linux-headers                   && \
+  rm -rf /go-ethereum && rm -rf /var/cache/apk/*
+
+FROM alpine:latest
+RUN apk add --update bash curl jq
+COPY --from=builder /usr/local/bin/geth /usr/local/bin/geth
+
+# Generate the version.txt file.
+RUN /usr/local/bin/geth console --exec 'console.log(admin.nodeInfo.name)' --maxpeers=0 --nodiscover --dev 2>/dev/null | head -1 > /version.txt
+
+# Inject the startup script.
+ADD geth.sh /geth.sh
+ADD mapper.jq /mapper.jq
+RUN chmod +x /geth.sh
+
+# Inject the enode id retriever script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Add a default genesis file.
+ADD genesis.json /genesis.json
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8547 8551 30303 30303/udp
+
+ENTRYPOINT ["/geth.sh"]

--- a/clients/bera-geth/Dockerfile.local
+++ b/clients/bera-geth/Dockerfile.local
@@ -1,0 +1,37 @@
+## Build geth from source from a local directory called go-ethereum.
+
+FROM golang:1-alpine as builder
+
+# Default local client path: clients/go-ethereum/<go-ethereum>
+ARG local_path=go-ethereum
+COPY $local_path go-ethereum
+
+WORKDIR go-ethereum
+RUN apk add --update bash curl jq git make gcc libc-dev linux-headers
+RUN make geth
+RUN mv ./build/bin/geth /usr/local/bin/geth
+
+FROM alpine:latest
+RUN apk add --update bash curl jq
+COPY --from=builder /usr/local/bin/geth /usr/local/bin/geth
+
+# Generate the version.txt file.
+RUN /usr/local/bin/geth console --exec 'console.log(admin.nodeInfo.name)' --maxpeers=0 --nodiscover --dev 2>/dev/null | head -1 > /version.txt
+
+# Inject the startup script.
+ADD geth.sh /geth.sh
+ADD mapper.jq /mapper.jq
+RUN chmod +x /geth.sh
+
+# Inject the enode id retriever script.
+RUN mkdir /hive-bin
+ADD enode.sh /hive-bin/enode.sh
+RUN chmod +x /hive-bin/enode.sh
+
+# Add a default genesis file.
+ADD genesis.json /genesis.json
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 8546 8547 8551 30303 30303/udp
+
+ENTRYPOINT ["/geth.sh"]

--- a/clients/bera-geth/README.md
+++ b/clients/bera-geth/README.md
@@ -1,13 +1,13 @@
 ## Changes
 
-1. Copy the `clients/go-ethereum` directory to `clients/bera-geth`.
+1. Copy the `clients/go-ethereum` directory to create `clients/bera-geth`:
 
 ```sh
 cd clients/
 cp -r go-ethereum bera-geth
 ```
 
-2. Update the image and version in `Dockerfile`.
+2. Update the base image and version in `Dockerfile`:
 
 ```diff
 - ARG baseimage=ethereum/client-go
@@ -18,7 +18,7 @@ cp -r go-ethereum bera-geth
 + ARG tag=v1.011602.1
 ```
 
-3. Update the binary.
+3. Replace the `geth` binary with `bera-geth` in `Dockerfile`:
 
 ```diff
 - COPY --from=builder /usr/local/bin/geth /usr/local/bin/geth
@@ -26,3 +26,13 @@ cp -r go-ethereum bera-geth
 + # Use bera-geth instead of geth
 + COPY --from=builder /usr/local/bin/bera-geth /usr/local/bin/geth
 ```
+
+## Running simulation tests
+
+Simulations from [`devp2p`](../../simulators/devp2p/) and [`ethereum`](../../simulators/ethereum/) were executed to compare the behavior of `bera-geth` with `go-ethereum`. Results indicate that `bera-geth` operates equivalently in these scenarios.
+
+
+| Test              | Output of `bera-geth` | Output of  `go-ethereum` | Command                                                       | Comments                                                                                                                                                                          |
+|-------------------|-----------------------|--------------------------|---------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `devp2p`          | 82/100                | 82/100                   | `./hive --sim devp2p --client go-ethereum,bera-geth`          | - `discv4` suite has a completion of 32/32 <br> - `discv5` suite has a completion of 6/16<br> - `eth` suite has a completion of 36/40<br> - `snap` suite has a completion of 8/12 |
+| `ethereum/engine` | 323/403               | 323/403                  | `./hive --sim ethereum/engine --client go-ethereum,bera-geth` |                                                                                                                                                                                   |                                                                                                                                                                              |

--- a/clients/bera-geth/README.md
+++ b/clients/bera-geth/README.md
@@ -1,0 +1,28 @@
+## Changes
+
+1. Copy the `clients/go-ethereum` directory to `clients/bera-geth`.
+
+```sh
+cd clients/
+cp -r go-ethereum bera-geth
+```
+
+2. Update the image and version in `Dockerfile`.
+
+```diff
+- ARG baseimage=ethereum/client-go
+- ARG tag=latest
+
++ # Pull bera-geth image
++ ARG baseimage=ghcr.io/berachain/bera-geth
++ ARG tag=v1.011602.1
+```
+
+3. Update the binary.
+
+```diff
+- COPY --from=builder /usr/local/bin/geth /usr/local/bin/geth
+
++ # Use bera-geth instead of geth
++ COPY --from=builder /usr/local/bin/bera-geth /usr/local/bin/geth
+```

--- a/clients/bera-geth/enode.sh
+++ b/clients/bera-geth/enode.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Script to retrieve the enode
+# 
+# This is copied into the validator container by Hive
+# and used to provide a client-specific enode id retriever
+#
+
+# Immediately abort the script on any error encountered
+set -e
+
+
+TARGET_RESPONSE=$(curl -s -X POST  -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}' "localhost:8545" )
+
+
+TARGET_ENODE=$(echo ${TARGET_RESPONSE}| jq -r '.result.enode')
+echo "$TARGET_ENODE"

--- a/clients/bera-geth/genesis.json
+++ b/clients/bera-geth/genesis.json
@@ -1,0 +1,15 @@
+{
+    "coinbase"   : "0x8888f1f195afa192cfee860698584c030f4c9db1",
+    "difficulty" : "0x020000",
+    "extraData"  : "0x42",
+    "gasLimit"   : "0x2fefd8",
+    "mixHash"    : "0x2c85bcbce56429100b2108254bb56906257582aeafcbd682bc9af67a9f5aee46",
+    "nonce"      : "0x78cc16f7b4f65485",
+    "parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "timestamp"  : "0x54c98c81",
+    "alloc"      : {
+        "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+            "balance" : "0x09184e72a000"
+        }
+    }
+}

--- a/clients/bera-geth/geth.sh
+++ b/clients/bera-geth/geth.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# Startup script to initialize and boot a go-ethereum instance.
+#
+# This script assumes the following files:
+#  - `geth` binary is located in the filesystem root
+#  - `genesis.json` file is located in the filesystem root (mandatory)
+#  - `chain.rlp` file is located in the filesystem root (optional)
+#  - `blocks` folder is located in the filesystem root (optional)
+#  - `keys` folder is located in the filesystem root (optional)
+#
+# This script assumes the following environment variables:
+#
+#  - HIVE_BOOTNODE                enode URL of the remote bootstrap node
+#  - HIVE_NETWORK_ID              network ID number to use for the eth protocol
+#  - HIVE_NODETYPE                sync and pruning selector (archive, full, light)
+#
+# Forks:
+#
+#  - HIVE_FORK_HOMESTEAD          block number of the homestead hard-fork transition
+#  - HIVE_FORK_DAO_BLOCK          block number of the DAO hard-fork transition
+#  - HIVE_FORK_DAO_VOTE           whether the node support (or opposes) the DAO fork
+#  - HIVE_FORK_TANGERINE          block number of Tangerine Whistle transition
+#  - HIVE_FORK_SPURIOUS           block number of Spurious Dragon transition
+#  - HIVE_FORK_BYZANTIUM          block number for Byzantium transition
+#  - HIVE_FORK_CONSTANTINOPLE     block number for Constantinople transition
+#  - HIVE_FORK_PETERSBURG         block number for ConstantinopleFix/PetersBurg transition
+#  - HIVE_FORK_ISTANBUL           block number for Istanbul transition
+#  - HIVE_FORK_MUIRGLACIER        block number for Muir Glacier transition
+#  - HIVE_FORK_BERLIN             block number for Berlin transition
+#  - HIVE_FORK_LONDON             block number for London
+#
+# Clique PoA:
+#
+#  - HIVE_CLIQUE_PERIOD           enables clique support. value is block time in seconds.
+#  - HIVE_CLIQUE_PRIVATEKEY       private key for clique mining
+#
+# Other:
+#
+#  - HIVE_MINER                   enable mining. value is coinbase address.
+#  - HIVE_MINER_EXTRA             extra-data field to set for newly minted blocks
+#  - HIVE_LOGLEVEL                client loglevel (0-5)
+#  - HIVE_GRAPHQL_ENABLED         enables graphql on port 8545
+#  - HIVE_LES_SERVER              set to '1' to enable LES server
+
+# Immediately abort the script on any error encountered
+set -e
+
+geth=/usr/local/bin/geth
+FLAGS="--state.scheme=path"
+
+if [ "$HIVE_LOGLEVEL" != "" ]; then
+    FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL"
+fi
+
+# It doesn't make sense to dial out, use only a pre-set bootnode.
+FLAGS="$FLAGS --bootnodes=$HIVE_BOOTNODE"
+
+# If a specific network ID is requested, use that
+if [ "$HIVE_NETWORK_ID" != "" ]; then
+    FLAGS="$FLAGS --networkid $HIVE_NETWORK_ID"
+else
+    # Unless otherwise specified by hive, we try to avoid mainnet networkid. If geth detects mainnet network id,
+    # then it tries to bump memory quite a lot
+    FLAGS="$FLAGS --networkid 1337"
+fi
+
+# Handle any client mode or operation requests
+if [ "$HIVE_NODETYPE" == "archive" ]; then
+    FLAGS="$FLAGS --syncmode full --gcmode archive"
+fi
+if [ "$HIVE_NODETYPE" == "full" ]; then
+    FLAGS="$FLAGS --syncmode full"
+fi
+if [ "$HIVE_NODETYPE" == "light" ]; then
+    FLAGS="$FLAGS --syncmode light"
+fi
+if [ "$HIVE_NODETYPE" == "snap" ]; then
+    FLAGS="$FLAGS --syncmode snap"
+fi
+if [ "$HIVE_NODETYPE" == "" ]; then
+    FLAGS="$FLAGS --syncmode snap"
+fi
+
+# Configure the chain.
+mv /genesis.json /genesis-input.json
+jq -f /mapper.jq /genesis-input.json > /genesis.json
+
+# Dump genesis. 
+if [ "$HIVE_LOGLEVEL" -lt 4 ]; then
+    echo "Supplied genesis state (trimmed, use --sim.loglevel 4 or 5 for full output):"
+    jq 'del(.alloc[] | select(.balance == "0x123450000000000000000"))' /genesis.json
+else
+    echo "Supplied genesis state:"
+    cat /genesis.json
+fi
+
+# Initialize the local testchain with the genesis state
+echo "Initializing database with genesis state..."
+$geth $FLAGS init /genesis.json
+
+# Don't immediately abort, some imports are meant to fail
+set +e
+
+# Load the test chain if present
+echo "Loading initial blockchain..."
+if [ -f /chain.rlp ]; then
+    $geth $FLAGS import /chain.rlp
+else
+    echo "Warning: chain.rlp not found."
+fi
+
+# Load the remainder of the test chain
+echo "Loading remaining individual blocks..."
+if [ -d /blocks ]; then
+    (cd /blocks && $geth $FLAGS --gcmode=archive --verbosity=$HIVE_LOGLEVEL import --nocompaction `ls | sort -n`)
+else
+    echo "Warning: blocks folder not found."
+fi
+
+set -e
+
+# Import clique signing key.
+if [ "$HIVE_CLIQUE_PRIVATEKEY" != "" ]; then
+    # Create password file.
+    echo "Importing clique key..."
+    echo "secret" > /geth-password-file.txt
+    $geth account import --password /geth-password-file.txt <(echo "$HIVE_CLIQUE_PRIVATEKEY")
+
+    # Ensure password file is used when running geth in mining mode.
+    if [ "$HIVE_MINER" != "" ]; then
+        FLAGS="$FLAGS --password /geth-password-file.txt --unlock $HIVE_MINER --allow-insecure-unlock"
+    fi
+fi
+
+# Configure any mining operation
+if [ "$HIVE_MINER" != "" ] && [ "$HIVE_NODETYPE" != "light" ]; then
+    FLAGS="$FLAGS --mine --miner.etherbase $HIVE_MINER"
+fi
+if [ "$HIVE_MINER_EXTRA" != "" ]; then
+    FLAGS="$FLAGS --miner.extradata $HIVE_MINER_EXTRA"
+fi
+
+# Configure LES.
+if [ "$HIVE_LES_SERVER" == "1" ]; then
+  FLAGS="$FLAGS --light.serve 50 --light.nosyncserve"
+fi
+
+# Configure RPC.
+FLAGS="$FLAGS --http --http.addr=0.0.0.0 --http.port=8545 --http.api=admin,debug,eth,miner,net,personal,txpool,web3"
+FLAGS="$FLAGS --ws --ws.addr=0.0.0.0 --ws.origins \"*\" --ws.api=admin,debug,eth,miner,net,personal,txpool,web3"
+
+if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
+    echo "0x7365637265747365637265747365637265747365637265747365637265747365" > /jwtsecret
+    FLAGS="$FLAGS --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.jwtsecret /jwtsecret"
+fi
+
+# Configure GraphQL.
+if [ "$HIVE_GRAPHQL_ENABLED" != "" ]; then
+    FLAGS="$FLAGS --graphql"
+fi
+# used for the graphql to allow submission of unprotected tx
+if [ "$HIVE_ALLOW_UNPROTECTED_TX" != "" ]; then
+    FLAGS="$FLAGS --rpc.allow-unprotected-txs"
+fi
+
+# Run the go-ethereum implementation with the requested flags.
+FLAGS="$FLAGS --nat=none"
+# Disable disk space free monitor
+FLAGS="$FLAGS --datadir.minfreedisk=0"
+echo "Running go-ethereum with flags $FLAGS"
+$geth $FLAGS

--- a/clients/bera-geth/hive.yaml
+++ b/clients/bera-geth/hive.yaml
@@ -1,0 +1,4 @@
+roles:
+  - "eth1"
+  - "eth1_les_client"
+  - "eth1_les_server"

--- a/clients/bera-geth/mapper.jq
+++ b/clients/bera-geth/mapper.jq
@@ -1,0 +1,81 @@
+# Removes all empty keys and values in input.
+def remove_empty:
+  . | walk(
+    if type == "object" then
+      with_entries(
+        select(
+          .value != null and
+          .value != "" and
+          .value != [] and
+          .key != null and
+          .key != ""
+        )
+      )
+    else .
+    end
+  )
+;
+
+# Converts decimal string to number.
+def to_int:
+  if . == null then . else .|tonumber end
+;
+
+# Converts "1" / "0" to boolean.
+def to_bool:
+  if . == null then . else
+    if . == "1" then true else false end
+  end
+;
+
+# Replace config in input.
+. + {
+  "config": {
+    "ethash": (if env.HIVE_CLIQUE_PERIOD then null else {} end),
+    "clique": (if env.HIVE_CLIQUE_PERIOD == null then null else {
+      "period": env.HIVE_CLIQUE_PERIOD|to_int,
+    } end),
+    "chainId": env.HIVE_CHAIN_ID|to_int,
+    "homesteadBlock": env.HIVE_FORK_HOMESTEAD|to_int,
+    "daoForkBlock": env.HIVE_FORK_DAO_BLOCK|to_int,
+    "daoForkSupport": env.HIVE_FORK_DAO_VOTE|to_bool,
+    "eip150Block": env.HIVE_FORK_TANGERINE|to_int,
+    "eip150Hash": env.HIVE_FORK_TANGERINE_HASH,
+    "eip155Block": env.HIVE_FORK_SPURIOUS|to_int,
+    "eip158Block": env.HIVE_FORK_SPURIOUS|to_int,
+    "byzantiumBlock": env.HIVE_FORK_BYZANTIUM|to_int,
+    "constantinopleBlock": env.HIVE_FORK_CONSTANTINOPLE|to_int,
+    "petersburgBlock": env.HIVE_FORK_PETERSBURG|to_int,
+    "istanbulBlock": env.HIVE_FORK_ISTANBUL|to_int,
+    "muirGlacierBlock": env.HIVE_FORK_MUIR_GLACIER|to_int,
+    "berlinBlock": env.HIVE_FORK_BERLIN|to_int,
+    "londonBlock": env.HIVE_FORK_LONDON|to_int,
+    "arrowGlacierBlock": env.HIVE_FORK_ARROW_GLACIER|to_int,
+    "grayGlacierBlock": env.HIVE_FORK_GRAY_GLACIER|to_int,
+    "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
+    "terminalTotalDifficulty": (env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int // 9223372036854775807),
+    "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
+    "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
+    "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
+    "osakaTime": env.HIVE_OSAKA_TIMESTAMP|to_int,
+    "terminalTotalDifficultyPassed": true,
+    "blobSchedule": {
+      "cancun": {
+        "target": (if env.HIVE_CANCUN_BLOB_TARGET then env.HIVE_CANCUN_BLOB_TARGET|to_int else 3 end),
+        "max": (if env.HIVE_CANCUN_BLOB_MAX then env.HIVE_CANCUN_BLOB_MAX|to_int else 6 end),
+        "baseFeeUpdateFraction": (if env.HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_CANCUN_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 3338477 end)
+      },
+      "prague": {
+        "target": (if env.HIVE_PRAGUE_BLOB_TARGET then env.HIVE_PRAGUE_BLOB_TARGET|to_int else 6 end),
+        "max": (if env.HIVE_PRAGUE_BLOB_MAX then env.HIVE_PRAGUE_BLOB_MAX|to_int else 9 end),
+        "baseFeeUpdateFraction": (if env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_PRAGUE_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 5007716 end)
+      },
+      "osaka": {
+        "target": (if env.HIVE_OSAKA_BLOB_TARGET then env.HIVE_OSAKA_BLOB_TARGET|to_int else 6 end),
+        "max": (if env.HIVE_OSAKA_BLOB_MAX then env.HIVE_OSAKA_BLOB_MAX|to_int else 9 end),
+        "baseFeeUpdateFraction": (if env.HIVE_OSAKA_BLOB_BASE_FEE_UPDATE_FRACTION then env.HIVE_OSAKA_BLOB_BASE_FEE_UPDATE_FRACTION|to_int else 5007716 end)
+      }
+    },
+    "depositContractAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa"
+  }|remove_empty
+}


### PR DESCRIPTION
This PR introduces support for running `bera-geth` as a client for Hive, which is duplicated from `clients/go-ethereum`. The changes are described in the `README.md` file, along with the simulation test results.